### PR TITLE
Create records functionality additions.

### DIFF
--- a/VividTracker/ClientApp/src/components/ManageTracker/ManageTracker.js
+++ b/VividTracker/ClientApp/src/components/ManageTracker/ManageTracker.js
@@ -485,6 +485,7 @@ export default class ManageTracker extends Component {
         })
         .then((res) => {
             this.getTrackingGroupTrackingItems(trackingGroupId)
+            this.getAllTrackingItems()
         })
         .catch((err) => {
         })
@@ -494,6 +495,36 @@ export default class ManageTracker extends Component {
         await this.getTrackingItemById(trackerItemID)
     }
 
+    handleAddRecord = async(recordID) =>
+    {
+        let targetRecord = this.state.allRecords.filter((record) => record.id == recordID)[0]
+        await this.addRecord(targetRecord)
+    }
+
+    addRecord = async(targetRedord) => {
+        const token = await authService.getAccessToken();
+        let pageLocationSplitted = window.location.href.split('/')
+        let trackingGroupId = pageLocationSplitted[pageLocationSplitted.length - 1]
+        let url = endpoints.createTrackingGroupRecord(trackingGroupId)
+        await fetch(url,
+            {
+                method: 'POST',
+                body:
+                    JSON.stringify({ 
+                        "Name": targetRedord.name, 
+                        "Disabled": true
+                    }),
+                headers:
+                {
+                    'Content-type': 'application/json; charset=UTF-8',
+                    'Authorization': `Bearer ${token}`
+                },
+            })
+            .then((res) => {
+                this.getTrackingGroupRecords()
+                this.getAllRecords()
+            })
+    }
     
     createRecord = async () => {
         const token = await authService.getAccessToken();
@@ -653,7 +684,7 @@ export default class ManageTracker extends Component {
                                             return (
                                                 <div className='AlreadyExistingRecord' key={alreadyExistingRecord.id}>
                                                     <p className='AlreadyExistingRecordName'>{alreadyExistingRecord.name}</p>
-                                                    <span className='AddTrackingButton'>Add</span>
+                                                    <span className='AddTrackingButton' onClick={() => this.handleAddRecord(alreadyExistingRecord.id)}>Add</span>
                                                 </div>
                                             )
                                         })}

--- a/VividTracker/ClientApp/src/components/ManageTracker/ManageTracker.js
+++ b/VividTracker/ClientApp/src/components/ManageTracker/ManageTracker.js
@@ -58,6 +58,7 @@ export default class ManageTracker extends Component {
             currentTrackingGroup: [],
             currentTrackerName: '',
             newTrackerName: '',
+            newLabelName: '',
             currentTrackerItems: [],
             PropertyTypes: {
                 'Bool': 1,
@@ -168,6 +169,7 @@ export default class ManageTracker extends Component {
                     this.setState({ 'currentTrackerName': result.name })
                     this.setState({ 'currentRecordName': result.label })
                     this.setState({ 'newTrackerName': result.name })
+                    this.setState({ 'newLabelName': result.label })
                 }))
             .catch((err) => {
                 // TODO: Do some action when an error occurs
@@ -207,19 +209,19 @@ export default class ManageTracker extends Component {
         }
         else {
             //TODO: Tell the user the new tracker name is invalid
-            console.log('invalid tracker name error')
+            console.log('An error occured while attempting to update the tracker name: The length of the tracker name should be between 0 and 50 (inclusive), and it should not be the same as the old one.')
         }
     }
 
     updateTrackerLabel = async (trackingGroupId) => {
-        if (this.checkIfItemNameIsValid(this.state.newTrackerName)) {
+        if (this.checkIfRecordNameIsValid(this.state.newLabelName)) {
             const token = await authService.getAccessToken();
             let url = endpoints.updateTrackerLabel(trackingGroupId)
             await fetch(url,
                 {
                     method: 'PATCH',
                     body:
-                        JSON.stringify({ "Label": this.state.currentRecordName }),
+                        JSON.stringify({ "Label": this.state.newLabelName }),
                     headers:
                     {
                         'Content-type': 'application/json; charset=UTF-8',
@@ -237,6 +239,7 @@ export default class ManageTracker extends Component {
         }
         else {
             //TODO: Tell the user the new tracker name is invalid
+            console.log('An error occured while attempting to update the tracker label: The length of the tracker label should be between 0 and 50 (inclusive), and it should not be the same as the old one.')
         }
     }
 
@@ -404,16 +407,24 @@ export default class ManageTracker extends Component {
             return true
         }
     }
-    checkIfItemNameIsValid(ItemName) {
+    checkIfItemNameIsValid(itemName) {
 
-        if (ItemName.length > 0 && ItemName.length <= 255) {
+        if (itemName.length > 0 && itemName.length <= 255 && itemName != this.state.currentTrackerName) {
             return true
         }
         else {
             return false
         }
     }
-
+    checkIfRecordNameIsValid(recordName)
+    {
+        if (recordName.length > 0 && recordName.length <= 50 && recordName != this.state.currentRecordName) {
+            return true
+        }
+        else {
+            return false
+        }
+    }
     checkIfValueIsNullOrEmpty(value) {
         if (value == null || !value) {
             return false
@@ -608,7 +619,7 @@ export default class ManageTracker extends Component {
                                 </div>
                                 <div className='RecordNameFieldWrapper'>
                                     <label className='TrackerRecordLabel pageText'>Record Name: </label>
-                                    <input className='TrackerRecordInputField form-control' type='text' value={this.state.currentRecordName} onChange={(e) => this.setState({ 'currentRecordName': e.target.value })} />
+                                    <input className='TrackerRecordInputField form-control' type='text' value={this.state.newLabelName} onChange={(e) => this.setState({ 'newLabelName': e.target.value })} />
                                 </div>
                             </div>
                             <div className='TrackerButtons'>

--- a/VividTracker/ClientApp/src/components/ManageTracker/ManageTracker.js
+++ b/VividTracker/ClientApp/src/components/ManageTracker/ManageTracker.js
@@ -491,11 +491,7 @@ export default class ManageTracker extends Component {
     }
     
     handleAddTrackerItem = async(trackerItemID) => {
-        // 1.getTrackingItemByID
-        let targetResult = await this.getTrackingItemById(trackerItemID)
-
-        // 2.addTrackingItemToTrackingGroup
-        // 3.getTrackingGroupTrackingItems
+        await this.getTrackingItemById(trackerItemID)
     }
 
     
@@ -645,7 +641,7 @@ export default class ManageTracker extends Component {
                                 </div>
                                     <div className={this.state.isCreateRecordSelected == true ? 'RecordsInteractionFieldWrapper d-flex' : 'RecordsInteractionFieldWrapper d-none'}>
                                         <label className='RecordNameLabel pageText'>New Record: </label>
-                                        <input className='RecordNameInputField form-control' type='text' value={this.state.newRecordName} onChange={(e) => this.setState({ 'newRecordName': e.target.value })} />
+                                        <input className='RecordNameInputField form-control' type='text' maxLength={50} value={this.state.newRecordName} onChange={(e) => this.setState({ 'newRecordName': e.target.value })} />
                                     </div>
                                     <div className={this.state.isCreateRecordSelected == true ? 'RecordButtonsManageTrackerPage': 'd-none'}>
                                         <span className='CancelButtonManageTrackerPage'><strong>Cancel</strong></span>

--- a/VividTracker/ClientApp/src/endpoints.js
+++ b/VividTracker/ClientApp/src/endpoints.js
@@ -20,6 +20,7 @@ export const endpoints = {
     updateTrackerLabel: (trackingGroupId) => `${apiBaseUrl}/api/trackingGroup/edit/label/${trackingGroupId}`,
     // getTrackingGroupTrackingItems: (trackingGroupId) => ${apiBaseUrl}/api/trackingGroup/${trackingGroupId}/trackingItems,
     getTrackingGroupTrackingItems: (trackingGroupId) => `${apiBaseUrl}/api/getTrackingItemByTrackingGroupId/${trackingGroupId}`,
+    getTrackingItemById: (trackingItemId) => `${apiBaseUrl}/api/getTrackingItem/${trackingItemId}`,
     resetName: (trackingGroupId) => `${apiBaseUrl}/api/reset/tracker/${trackingGroupId}`,
     editTracker: (trackerId) => `${apiBaseUrl}/api/editTracker/${trackerId}`,
     getAllRecords: () => `${apiBaseUrl}/api/trackingGroupsRecords`,


### PR DESCRIPTION
- Users can now add records and items from the "already existing" sections on the manage tracker page.
- The create new record input field is now limited to 50 characters, as required by the JIRA story.
- The bug, which caused the update tracker name and label functionality to show an error in the console is resolved.