### PR TITLE
Fixing the issue of duplicated names.

### DIFF
--- a/VividTracker.Business/Services/Interfaces/ITenantsService.cs
+++ b/VividTracker.Business/Services/Interfaces/ITenantsService.cs
@@ -14,7 +14,7 @@ namespace VividTracker.Business.Services.Interfaces
         Task<Tenant?> GetTenantByTaskIdAsync(Task<int?> id);
 
         Task UpdateTenantAsync(Tenant tenant);
-        Task AddTenantAsync(Tenant tenant);
+        Task<Tenant?> AddTenantAsync(Tenant tenant);
         Task<Tenant?> GetTenantByNameAsync(string name);
     }
 }

--- a/VividTracker.Business/Services/TenantsService.cs
+++ b/VividTracker.Business/Services/TenantsService.cs
@@ -19,8 +19,22 @@ public class TenantsService : ITenantsService
 
     public async Task UpdateTenantAsync(Tenant tenant) => await _tenantsRepository.UpdateAsync(tenant);
 
-    public async Task AddTenantAsync(Tenant tenant) => await _tenantsRepository.AddAsync(tenant);
+    public async Task<Tenant?> AddTenantAsync(Tenant tenant)
+    {
+        var allTenants = await GetTenantsAsync();
+        var name = tenant.Name.Trim();
 
+        var isExist = allTenants.Any(t => t.Name.ToUpper() == name.ToUpper());
+        if (!string.IsNullOrWhiteSpace(name))
+        {
+            if (!isExist)
+            {
+                await _tenantsRepository.AddAsync(tenant);
+            }
+        }
+
+        return null;
+    }
     public async Task<Tenant?> GetTenantByNameAsync(string name)
     {
         return await _tenantsRepository.GetTenantByName(name);

--- a/VividTracker.Business/Services/TrackingGroupRecordService.cs
+++ b/VividTracker.Business/Services/TrackingGroupRecordService.cs
@@ -21,8 +21,9 @@
         {
             var allRecords = await _trackingGroupRecordsRepository.GetAllRecordsAsync(trackingGroupRecord.TrackingGroupId);
             var recordsName = allRecords.Select(t => t.Name).ToList();
-
-            if (recordsName.Any(t=>t.ToUpper().Trim() == trackingGroupRecord.Name.ToUpper().Trim()))
+            var name = trackingGroupRecord.Name.Trim();
+           
+            if (recordsName.Any(t=>t.ToUpper() == name.ToUpper()) || string.IsNullOrWhiteSpace(name))
             {
                 return null;
             }

--- a/VividTracker.Business/Services/TrackingGroupsService.cs
+++ b/VividTracker.Business/Services/TrackingGroupsService.cs
@@ -47,8 +47,11 @@ namespace VividTracker.Business.Services
 
         public async Task<TrackingGroup> CreateTrackingGroup(TrackingGroup trackingGroup)
         {
-            var isExist = await _trackingGroupsRepository.GetTrackerByName(trackingGroup.Name);
-            if (isExist != null)
+            var name = trackingGroup.Name.Trim();
+            var allTrackingGroups = await GetTrackersAsync();
+            var isExist = allTrackingGroups.Any(x => x.Name.ToUpper() == name.ToUpper());
+
+            if (isExist || string.IsNullOrWhiteSpace(name))
             {
                 return null;
             }

--- a/VividTracker.Business/Services/TrackingItemsService.cs
+++ b/VividTracker.Business/Services/TrackingItemsService.cs
@@ -28,9 +28,11 @@
         {
 
             var trackers = await GetTrackingItemsByTrackingGroupId(trackingGroupId);
-            var isExist = trackers.FirstOrDefault(t => t.Name.ToUpper() == trackingItem.Name.ToUpper());
+            var name = trackingItem.Name.Trim();
 
-            if (isExist!=null)
+            var isExist = trackers.FirstOrDefault(t => t.Name.ToUpper() == name.ToUpper());
+
+            if (isExist!=null || string.IsNullOrWhiteSpace(name))
             {
                 return null;
             }

--- a/VividTracker/Controllers/TenantsController.cs
+++ b/VividTracker/Controllers/TenantsController.cs
@@ -76,8 +76,13 @@ namespace VividTracker.Controllers
                 return BadRequest("The tenant already exists");
             }
 
-            await _tenantsService.AddTenantAsync(createTenant);
-            return Ok(createTenant);
+           var result  =  await _tenantsService.AddTenantAsync(createTenant);
+           if (result != null)
+           {
+               return Ok(createTenant);
+           }
+
+           return BadRequest("Error");
         }
     }
 }


### PR DESCRIPTION
1. There is a check to verify if the Tenant already exists; if so, it won't be added. Additionally there is a check for spaces before and after the name. Also it is checked whether the input data contains only spaces for the name.

2. The same checks are in place for TrackingGroup, TrackingItem, and TrackingGroupRecord:

- There is a check to verify if the entity already exists and if so it won't be added.
- Additionally, there is a check for spaces before and after the name.
- Also it is checked whether the input data contains only spaces for the name.