### PR TITLE
Viv 40 use tracker page - updated the comments layout.

### DIFF
--- a/VividTracker/ClientApp/src/components/AddComment/AddComment.js
+++ b/VividTracker/ClientApp/src/components/AddComment/AddComment.js
@@ -84,7 +84,11 @@ export class AddComment extends Component {
                     }
             })
         }
-
+        else if(this.state.inputValue.length > 255)
+        {
+            this.setState({ errorMessage: errors.maxLength });
+            this.setState({ textColor: color.error });
+        }
     }
     createNumberItem = async () => {
         console.log(this.state.sliderValue);

--- a/VividTracker/ClientApp/src/components/AddComment/AddComment.js
+++ b/VividTracker/ClientApp/src/components/AddComment/AddComment.js
@@ -56,16 +56,9 @@ export class AddComment extends Component {
             error: "red",
             success: "green"
         }
-        if (this.state.inputValue.length < 1) {
-
-            this.setState({ errorMessage: errors.minLength });
-            this.setState({ textColor: color.error });
-        }
-        else if (this.state.inputValue.length > 255) {
-            this.setState({ errorMessage: errors.maxLength });
-            this.setState({ textColor: color.error });
-        }
-        else {
+        
+        if (this.state.inputValue.length >= 1 && this.state.inputValue.length <= 255)
+        {
             var url = endpoints.createComment(trackingItemId);
             await fetch(url, {
                 method: 'POST',
@@ -78,7 +71,7 @@ export class AddComment extends Component {
                     "UserId": userID 
                 })
             })
-                .then((response) => {
+            .then((response) => {
                     if (response.status != 200) {
                         this.setState({ textColor: color.error });
                         this.setState({ errorMessage: errors.invalid });
@@ -89,8 +82,9 @@ export class AddComment extends Component {
                         this.props.onCommentAdded(this.props.value);
                         this.state.inputValue = '';
                     }
-                })
+            })
         }
+
     }
     createNumberItem = async () => {
         console.log(this.state.sliderValue);

--- a/VividTracker/ClientApp/src/components/PanelComponent/PanelComponent.js
+++ b/VividTracker/ClientApp/src/components/PanelComponent/PanelComponent.js
@@ -201,8 +201,8 @@ export default class PanelComponent extends Component {
                                 this.state.comments.map((trackingItemValueActivityData) => {
                                 return (
                                     <PanelContainer 
-                                    trackingItemValueActivityData={trackingItemValueActivityData}
-                                    key={trackingItemValueActivityData.id}
+                                        trackingItemValueActivityData={trackingItemValueActivityData}
+                                        key={trackingItemValueActivityData.id}
                                     />   
                                 )
                                 

--- a/VividTracker/ClientApp/src/components/PanelContainer/PanelContainer.css
+++ b/VividTracker/ClientApp/src/components/PanelContainer/PanelContainer.css
@@ -20,13 +20,10 @@
     height: 15px;
     margin-left: 3px;
 }
-.managePanelIconWrapper{
-    margin-top: -33px;
-}
+
 .panelComment {
     color: black;
     font-size: 18px;
-    margin-left: 25px;
 }
 .panelCommentWrapper {
     margin-top: -3px;
@@ -40,11 +37,17 @@
 .dateWrapper {
     margin-top: 5px;
 }
-.userNameText {
-    font-size: 18px;
-    color: black;
-    margin-top: -5px;
-    margin-left: 3px;
-    font-weight: 400 !important;
+.commentDate{
+    font-family: Open Sans ;
+    font-size: 14px ;
+    font-weight: 400 ;
+    line-height: 11px ;
+    margin-left: 10%;
 }
 
+.userNameText {
+    font-size: 16px;
+    color: black;
+    font-weight: 700 !important;
+    display: inline;
+}

--- a/VividTracker/ClientApp/src/components/PanelContainer/PanelContainer.css
+++ b/VividTracker/ClientApp/src/components/PanelContainer/PanelContainer.css
@@ -23,7 +23,11 @@
 
 .panelComment {
     color: black;
-    font-size: 18px;
+    font-family: Open Sans;
+    font-size: 14px;
+    font-weight: 400 !important;
+    line-height: 13.62px;
+    
 }
 .panelCommentWrapper {
     margin-top: -3px;

--- a/VividTracker/ClientApp/src/components/PanelContainer/PanelContainer.js
+++ b/VividTracker/ClientApp/src/components/PanelContainer/PanelContainer.js
@@ -7,28 +7,25 @@ export default class PanelContainer extends Component {
     render() {
         const date = new Date(this.props.trackingItemValueActivityData.timeStamp);
         const formattedDate = date.toLocaleDateString("en-GB");
+        let month = date.toString().split(' ')[1]
+        let day = date.toString().split(' ')[2]
         return (
-            <div className='panelContainerIndividual d-flex' key={this.props.trackingItemValueActivityData.id}>
-                <div className='panelContentContainer'>
-                    <div className='userNameWrapper ml-auto'>
-                        <span className='userNameText pageText'>
+                <div className='panelContainerIndividual' key={this.props.trackingItemValueActivityData.id}>
+                
+                    <div className='userNameWrapper'>
+                        <span className='userNameText commentUsername'>
                             {this.props.trackingItemValueActivityData.user.userName}
+                        </span>
+                        <span className='dateText commentDate'>
+                            {month + ' ' + day}
                         </span>
                     </div>
                     <div className='panelCommentWrapper'>
+                        <FontAwesomeIcon className='commentsIcon' icon={faComments} />
                         <span className='panelComment pageText'> {this.props.trackingItemValueActivityData.comment}
                         </span>
                     </div>
-                    <div className='managePanelIconWrapper ml-auto'>
-                        <FontAwesomeIcon className='commentsIcon' icon={faComments} />
-                    </div>
-                    <div className='dateWrapper ml-auto'>
-                        <span className='dateText pageText'>
-                            {formattedDate}
-                        </span>
-                    </div>
                 </div>
-            </div>
         )
     }
 }

--- a/VividTracker/ClientApp/src/components/PanelContainer/PanelContainer.js
+++ b/VividTracker/ClientApp/src/components/PanelContainer/PanelContainer.js
@@ -22,7 +22,7 @@ export default class PanelContainer extends Component {
                     </div>
                     <div className='panelCommentWrapper'>
                         <FontAwesomeIcon className='commentsIcon' icon={faComments} />
-                        <span className='panelComment pageText'> {this.props.trackingItemValueActivityData.comment}
+                        <span className='panelComment '> {this.props.trackingItemValueActivityData.comment}
                         </span>
                     </div>
                 </div>


### PR DESCRIPTION
- The comments' date is now shown as the month in words + the day.
- The comments' date is now to the right of the comment poster's email.
- The comments' text is now of a smaller font than the comment poster's email.
- The comments' icon is now to the top-left of the comment/at its beginning as specified in the Figma design.